### PR TITLE
feat: replace fcitx5-unikey with fcitx5-lotus input method

### DIFF
--- a/CaramOS Project Finalization.md
+++ b/CaramOS Project Finalization.md
@@ -112,7 +112,7 @@ Nhiều nước đã làm tương tự:
 
 ### 1. **Việt hoá toàn diện**
 - Giao diện 100% tiếng Việt ngay từ cài đặt
-- **Bộ gõ tiếng Việt** (ibus-unikey / fcitx5-unikey) cài sẵn, hoạt động ngay
+- **Bộ gõ tiếng Việt** (fcitx5-lotus) cài sẵn, hoạt động ngay
 - Font chữ Việt đẹp mặc định (Google Noto, Be Vietnam Pro)
 - Hướng dẫn sử dụng bằng tiếng Việt tích hợp sẵn
 
@@ -234,7 +234,7 @@ Tuyệt vời! Bạn đã có **VNLF (Vietnam Linux Family)** — vậy là đã
 ```
 VNLF OS = Linux Mint (base)
          + Branding VNLF (wallpaper, logo, boot splash, icon)
-         + Unikey/ibus-unikey cài sẵn, bật sẵn
+         + Lotus cài sẵn, bật sẵn
          + Font tiếng Việt đẹp mặc định
          + LibreOffice tiếng Việt
          + Zalo Web PWA pinned sẵn

--- a/config/hooks/live/0150-fcitx5-lotus.hook.chroot
+++ b/config/hooks/live/0150-fcitx5-lotus.hook.chroot
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+export DEBIAN_FRONTEND=noninteractive
+APT_LOCK_TIMEOUT="${APT_LOCK_TIMEOUT:-600}"
+APT_GET=(apt-get -o DPkg::Lock::Timeout="${APT_LOCK_TIMEOUT}")
+
+echo "[CaramOS] Removing old fcitx5 packages..."
+"${APT_GET[@]}" remove -y fcitx5 fcitx5-unikey 2>/dev/null || true
+"${APT_GET[@]}" autoremove -y 2>/dev/null || true
+
+echo "[CaramOS] Installing fcitx5-lotus..."
+CODENAME=$(grep '^UBUNTU_CODENAME=' /etc/os-release | cut -d'=' -f2)
+if [ -z "$CODENAME" ]; then
+    CODENAME=noble
+fi
+
+mkdir -p /etc/apt/keyrings
+if ! ls /etc/apt/keyrings/fcitx5-lotus.gpg 2>/dev/null; then
+    curl -fsSL https://fcitx5-lotus.pages.dev/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/fcitx5-lotus.gpg
+fi
+
+printf 'deb [signed-by=/etc/apt/keyrings/fcitx5-lotus.gpg] https://fcitx5-lotus.pages.dev/apt/%s %s main\n' "$CODENAME" "$CODENAME" > /etc/apt/sources.list.d/fcitx5-lotus.list
+
+"${APT_GET[@]}" update -qq
+"${APT_GET[@]}" install -y fcitx5-lotus
+echo "[CaramOS] fcitx5-lotus installed successfully!"

--- a/config/packages.txt
+++ b/config/packages.txt
@@ -6,10 +6,6 @@
 
 # ChromeOS-style Dock
 plank
-
-# Bộ gõ tiếng Việt
-fcitx5
-fcitx5-unikey
 #5 @dungdinhmanh
 flameshot
 tlp


### PR DESCRIPTION
- Remove fcitx5 and fcitx5-unikey from packages.txt
- Add 0150-fcitx5-lotus.hook.chroot to install fcitx5-lotus via dedicated APT repo
- Hook handles GPG key, repo setup, and package installation
- Follows official fcitx5-lotus.pages.dev installation guide