### PR TITLE
feat: Thêm ZRAM mặc định 50% RAM

### DIFF
--- a/config/hooks/live/0110-zram-default.hook.chroot
+++ b/config/hooks/live/0110-zram-default.hook.chroot
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Hook: ZRAM mặc định 50% RAM
+set -e
+
+echo "[CaramOS] Configuring default ZRAM..."
+
+mkdir -p /etc/systemd
+cat > /etc/systemd/zram-generator.conf <<'ZRAM'
+[zram0]
+zram-size = ram / 2
+compression-algorithm = zstd
+swap-priority = 100
+ZRAM
+
+echo "[CaramOS] Default ZRAM configured."

--- a/config/packages.txt
+++ b/config/packages.txt
@@ -8,3 +8,6 @@ flameshot
 tlp
 #19
 copyq
+
+# ZRAM mặc định cho máy RAM thấp
+systemd-zram-generator

--- a/scripts/customize.sh
+++ b/scripts/customize.sh
@@ -68,6 +68,8 @@ step_customize() {
         set -e
         test -f /etc/dconf/db/local
         test -f /etc/xdg/autostart/caramos-theme.desktop
+        test -f /etc/systemd/zram-generator.conf
+        grep -q "^zram-size = ram / 2$" /etc/systemd/zram-generator.conf
         test -d /usr/share/cinnamon/applets/Cinnamenu@json
         find /usr/share/cinnamon/applets/Cinnamenu@json -name settings-schema.json -print -quit | grep -q .
         test -f /usr/share/plymouth/themes/caramos/caramos.plymouth


### PR DESCRIPTION
## Mô tả

Thêm ZRAM (compressed RAM-based swap) với cấu hình mặc định 50% RAM. Giúp cải thiện hiệu năng trên máy RAM thấp.

## Thay đổi

- Thêm package `systemd-zram-generator`
- Tạo hook cấu hình ZRAM: 50% allocation, zstd compression
- Thêm validation checks trong `customize.sh`

## Test

Đã test trên QEMU (CaramOS 1.0.1):
- ZRAM device: `/dev/zram0` (974M)
- Compression: zstd, ratio ~21%
- Status: Active [SWAP]
<img width="1280" height="800" alt="zram_caramos" src="https://github.com/user-attachments/assets/79e9a13f-c87f-4bc9-8e27-783c6a3a7b4d" />
