### PR TITLE
feat: Thêm applet âm thanh và applet mạng vào panel đồng thời điều chỉnh vị trí của các applet trên panel

### DIFF
--- a/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
+++ b/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
@@ -118,7 +118,7 @@ fi
 mkdir -p /etc/dconf/db/local.d
 cat > /etc/dconf/db/local.d/01-caramos-task17-panel <<'DCONF'
 [org/cinnamon]
-enabled-applets=['panel1:left:0:Cinnamenu@json', 'panel1:left:1:grouped-window-list@cinnamon.org', 'panel1:right:0:network@cinnamon.org', 'panel1:right:1:sound@cinnamon.org', 'panel1:right:2:weather@mockturtl', 'panel1:right:3:systray@cinnamon.org', 'panel1:right:4:notifications@cinnamon.org', 'panel1:right:5:power@cinnamon.org', 'panel1:right:6:calendar@cinnamon.org', 'panel1:right:7:cornerbar@cinnamon.org']
+enabled-applets=['panel1:left:0:Cinnamenu@json', 'panel1:left:1:grouped-window-list@cinnamon.org', 'panel1:right:0:systray@cinnamon.org', 'panel1:right:1:network@cinnamon.org', 'panel1:right:2:sound@cinnamon.org', 'panel1:right:3:notifications@cinnamon.org', 'panel1:right:4:power@cinnamon.org', 'panel1:right:5:calendar@cinnamon.org']
 panels-height=['1:32']
 panel-scale-text-icons=false
 panel-zone-icon-sizes='[{"panelId": 1, "maxSize": 18}]'

--- a/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
+++ b/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
@@ -118,7 +118,7 @@ fi
 mkdir -p /etc/dconf/db/local.d
 cat > /etc/dconf/db/local.d/01-caramos-task17-panel <<'DCONF'
 [org/cinnamon]
-enabled-applets=['panel1:left:0:Cinnamenu@json', 'panel1:left:1:grouped-window-list@cinnamon.org', 'panel1:right:0:weather@mockturtl', 'panel1:right:1:systray@cinnamon.org', 'panel1:right:2:notifications@cinnamon.org', 'panel1:right:3:power@cinnamon.org', 'panel1:right:4:calendar@cinnamon.org']
+enabled-applets=['panel1:left:0:Cinnamenu@json', 'panel1:left:1:grouped-window-list@cinnamon.org', 'panel1:right:0:network@cinnamon.org', 'panel1:right:1:sound@cinnamon.org', 'panel1:right:2:weather@mockturtl', 'panel1:right:3:systray@cinnamon.org', 'panel1:right:4:notifications@cinnamon.org', 'panel1:right:5:power@cinnamon.org', 'panel1:right:6:calendar@cinnamon.org', 'panel1:right:7:cornerbar@cinnamon.org']
 panels-height=['1:32']
 panel-scale-text-icons=false
 panel-zone-icon-sizes='[{"panelId": 1, "maxSize": 18}]'


### PR DESCRIPTION
Điều chỉnh cấu hình panel để hiển thị các applet mặc định hợp lý hơn cho CaramOS

## Thay đổi
- Đã thêm applet mạng (`network@cinnamon.org`) và applet âm thanh (`sound@cinnamon.org`) vào panel
- Điều chỉnh lại thứ tự applet trên panel:
  - đưa `systray` lên vị trí đầu tiên bên phải
  - bỏ `weather`
  - bỏ `cornerbar`

## Issue liên quan
- Fixes #37