### PR TITLE
feat: Thêm Software Manager vào panel và màn hình desktop

### DIFF
--- a/config/hooks/live/0100-caramos-setup.hook.chroot
+++ b/config/hooks/live/0100-caramos-setup.hook.chroot
@@ -215,7 +215,7 @@ font-name='Be Vietnam Pro 10'
 theme='Cinnamon-Delight'
 
 [org/cinnamon/applets/grouped-window-list]
-pinned-apps=['google-chrome.desktop','wps-office-prometheus.desktop','cinnamon-settings.desktop']
+pinned-apps=['cinnamon-settings.desktop','wps-office-prometheus.desktop','google-chrome.desktop','mintinstall.desktop']
 DCONF
 
 if [ -f /usr/share/applications/nemo.desktop ] && ! grep -q '^StartupWMClass=' /usr/share/applications/nemo.desktop; then

--- a/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
+++ b/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
@@ -127,7 +127,7 @@ panel-zone-text-sizes='[{"panelId": 1, "left":0.0, "center":0.0, "right":0.0}]'
 favorite-apps=@as []
 
 [org/cinnamon/applets/grouped-window-list]
-pinned-apps=['google-chrome.desktop','wps-office-prometheus.desktop','cinnamon-settings.desktop']
+pinned-apps=['cinnamon-settings.desktop','wps-office-prometheus.desktop','google-chrome.desktop','mintinstall.desktop']
 title-display=1
 number-display=false
 group-apps=true

--- a/config/hooks/live/0200-caramos-debrand.hook.chroot
+++ b/config/hooks/live/0200-caramos-debrand.hook.chroot
@@ -98,6 +98,16 @@ if [ -f /etc/skel/Desktop/ubiquity.desktop ]; then
     sed -i 's/Install Linux Mint/Install CaramOS/gI' /etc/skel/Desktop/ubiquity.desktop
 fi
 
+# Ghim Software Manager ra Desktop cho user mặc định
+SKEL_DESKTOP_DIR="/etc/skel/Desktop"
+mkdir -p "$SKEL_DESKTOP_DIR"
+if [ -f /usr/share/applications/mintinstall.desktop ]; then
+    cp -f /usr/share/applications/mintinstall.desktop "$SKEL_DESKTOP_DIR/mintinstall.desktop"
+    chmod +x "$SKEL_DESKTOP_DIR/mintinstall.desktop"
+    gio set "$SKEL_DESKTOP_DIR/mintinstall.desktop" metadata::trusted true 2>/dev/null || true
+    echo "[OK] Pin Software Manager to Desktop"
+fi
+
 # --- 5. Casper/Live session config ---
 echo "[CaramOS] Đổi casper config..."
 # File casper.conf hoặc live.conf

--- a/config/includes.chroot/etc/dconf/db/local.d/00-caramos-theme
+++ b/config/includes.chroot/etc/dconf/db/local.d/00-caramos-theme
@@ -29,4 +29,4 @@ font-name='Be Vietnam Pro 10'
 theme='Cinnamon-Delight'
 
 [org/cinnamon/applets/grouped-window-list]
-pinned-apps=['google-chrome.desktop','wps-office-prometheus.desktop','cinnamon-settings.desktop']
+pinned-apps=['cinnamon-settings.desktop','wps-office-prometheus.desktop','google-chrome.desktop','mintinstall.desktop']

--- a/config/includes.chroot/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/config/includes.chroot/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -153,9 +153,10 @@
   "pinned-apps": {
     "type": "generic",
     "default": [
-      "google-chrome.desktop",
+      "cinnamon-settings.desktop",
       "wps-office-prometheus.desktop",
-      "cinnamon-settings.desktop"
+      "google-chrome.desktop",
+      "mintinstall.desktop"
     ]
   },
   "group-apps": {


### PR DESCRIPTION
Ghim ứng dụng **Software Manager**  vào panel và tạo lối tắt trên màn hình chính (Desktop) để người dùng dễ dàng truy cập và cài đặt ứng dụng

## Issue liên quan
* Fixes: #49