### PR TITLE
fix: sửa lỗi icon system tray bị phóng to

### DIFF
--- a/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
+++ b/config/hooks/live/0170-cinnamon-task17-spices.hook.chroot
@@ -121,7 +121,7 @@ cat > /etc/dconf/db/local.d/01-caramos-task17-panel <<'DCONF'
 enabled-applets=['panel1:left:0:Cinnamenu@json', 'panel1:left:1:grouped-window-list@cinnamon.org', 'panel1:right:0:weather@mockturtl', 'panel1:right:1:systray@cinnamon.org', 'panel1:right:2:notifications@cinnamon.org', 'panel1:right:3:power@cinnamon.org', 'panel1:right:4:calendar@cinnamon.org']
 panels-height=['1:32']
 panel-scale-text-icons=false
-panel-zone-icon-sizes='[{"panelId": 1, "maxSize": 18}]'
+panel-zone-icon-sizes='[{"panelId": 1, "right": 18}]'
 panel-zone-symbolic-icon-sizes='[{"panelId": 1, "left": 20, "center": 20, "right": 16}]'
 panel-zone-text-sizes='[{"panelId": 1, "left":0.0, "center":0.0, "right":0.0}]'
 favorite-apps=@as []

--- a/config/includes.chroot/etc/dconf/db/local.d/00-caramos-theme
+++ b/config/includes.chroot/etc/dconf/db/local.d/00-caramos-theme
@@ -4,7 +4,7 @@ system-icon='/usr/share/pixmaps/caramos-logo.png'
 panels-enabled=['1:0:bottom']
 panels-autohide=['1:false']
 panels-height=['1:32']
-panel-zone-icon-sizes='[{"panelId": 1, "left": 20, "center": 20, "right": 20}]'
+panel-zone-icon-sizes='[{"panelId": 1, "right": 18}]'
 panel-zone-symbolic-icon-sizes='[{"panelId": 1, "left": 20, "center": 20, "right": 20}]'
 
 [org/cinnamon/theme]

--- a/config/includes.chroot/usr/bin/caramos-theme-apply
+++ b/config/includes.chroot/usr/bin/caramos-theme-apply
@@ -26,7 +26,7 @@ gsettings set org.gnome.desktop.background picture-uri "$WALLPAPER_URI" 2>/dev/n
 gsettings set org.cinnamon panels-enabled "['1:0:bottom']" 2>/dev/null || true
 gsettings set org.cinnamon panels-autohide "['1:false']" 2>/dev/null || true
 gsettings set org.cinnamon panels-height "['1:32']" 2>/dev/null || true
-gsettings set org.cinnamon panel-zone-icon-sizes '[{"panelId": 1, "maxSize": 24}]' 2>/dev/null || true
+gsettings set org.cinnamon panel-zone-icon-sizes '[{"panelId": 1, "right": 18}]' 2>/dev/null || true
 
 # Desktop: ẩn TẤT CẢ icon trên desktop (desktop style)
 gsettings set org.nemo.desktop computer-icon-visible false 2>/dev/null || true


### PR DESCRIPTION
## Mô tả

  Sửa lỗi icon system tray bị phóng to

## Thay đổi

  - Cập nhật dconf mặc định trong config/includes.chroot/etc/dconf/db/local.d/00-caramos-theme
  - Cập nhật script apply theme của live session trong config/includes.chroot/usr/bin/caramos-theme-apply
  - Cập nhật hook task17 panel trong config/hooks/live/0170-cinnamon-task17-spices.hook.chroot

## Test

  - Đã boot/test live ISO và xác nhận icon system tray không còn bị phóng to

## Issue liên quan

  - Fixes #57