### PR TITLE
chore: bump actions to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Free disk space
         run: |
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get install -y squashfs-tools xorriso rsync wget isolinux syslinux-utils build-essential debhelper
 
       - name: Cache Mint ISO
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: linuxmint-22.3-cinnamon-64bit.iso
           key: mint-iso-22.3-cinnamon
@@ -65,7 +65,7 @@ jobs:
         run: sha256sum CaramOS-*.iso > SHA256SUMS
 
       - name: Upload ISO artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: CaramOS-ISO
           path: |
@@ -146,7 +146,7 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             SHA256SUMS


### PR DESCRIPTION
### About:
Bump actions to latest (maybe) version.
### Whyyyy?????
Because GitHub deprecates node.js 24, update to prevent warning when CI runs.
### What's changed
View file changed on this PR