### PR TITLE
chore: delete file named `landing`

### DIFF
--- a/landing
+++ b/landing
@@ -1,1 +1,0 @@
-../CaramOSLanding


### PR DESCRIPTION
### tại sao:
Vì file tên `landing` trong kho lưu trữ (repo) được liệt kê trong `.gitignore`. Mà đã có trong `.gitignore` thì nó không nén tồn tại.
### Bằng chứng:
File tên `landing` đã được commit 2 tháng trước, mà cập nhật `.gitignore` để bao gồm thêm file `landing` vào danh sách tệp cần bỏ qua khi push code vào 1 tháng trước. Điều này chỉ ngăn push bản cập nhật của file này thay vì xoá nó. Nên tôi sẽ xoá hẳn file này.

Với lại tôi thấy file này khá vô dụng